### PR TITLE
React 15.5 compatibility

### DIFF
--- a/lib/agGridReact.js
+++ b/lib/agGridReact.js
@@ -7,7 +7,8 @@ var React = require('react');
 var ReactDOM = require('react-dom');
 var AgGrid = require('ag-grid');
 var PropTypes = require('prop-types');
-exports.AgGridReact = React.createClass({
+var createReactClass = require('create-react-class');
+exports.AgGridReact = createReactClass({
     render: function () {
         return React.DOM.div({
             style: this.createStyleForDiv()

--- a/lib/agGridReact.js
+++ b/lib/agGridReact.js
@@ -6,6 +6,7 @@ var reactFrameworkComponentWrapper_1 = require("./reactFrameworkComponentWrapper
 var React = require('react');
 var ReactDOM = require('react-dom');
 var AgGrid = require('ag-grid');
+var PropTypes = require('prop-types');
 exports.AgGridReact = React.createClass({
     render: function () {
         return React.DOM.div({
@@ -69,15 +70,15 @@ exports.AgGridReact = React.createClass({
     }
 });
 exports.AgGridReact.propTypes = {
-    gridOptions: React.PropTypes.object,
+    gridOptions: PropTypes.object,
 };
-addProperties(AgGrid.ComponentUtil.getEventCallbacks(), React.PropTypes.func);
-addProperties(AgGrid.ComponentUtil.BOOLEAN_PROPERTIES, React.PropTypes.bool);
-addProperties(AgGrid.ComponentUtil.STRING_PROPERTIES, React.PropTypes.string);
-addProperties(AgGrid.ComponentUtil.OBJECT_PROPERTIES, React.PropTypes.object);
-addProperties(AgGrid.ComponentUtil.ARRAY_PROPERTIES, React.PropTypes.array);
-addProperties(AgGrid.ComponentUtil.NUMBER_PROPERTIES, React.PropTypes.number);
-addProperties(AgGrid.ComponentUtil.FUNCTION_PROPERTIES, React.PropTypes.func);
+addProperties(AgGrid.ComponentUtil.getEventCallbacks(), PropTypes.func);
+addProperties(AgGrid.ComponentUtil.BOOLEAN_PROPERTIES, PropTypes.bool);
+addProperties(AgGrid.ComponentUtil.STRING_PROPERTIES, PropTypes.string);
+addProperties(AgGrid.ComponentUtil.OBJECT_PROPERTIES, PropTypes.object);
+addProperties(AgGrid.ComponentUtil.ARRAY_PROPERTIES, PropTypes.array);
+addProperties(AgGrid.ComponentUtil.NUMBER_PROPERTIES, PropTypes.number);
+addProperties(AgGrid.ComponentUtil.FUNCTION_PROPERTIES, PropTypes.func);
 function addProperties(listOfProps, propType) {
     listOfProps.forEach(function (propKey) {
         exports.AgGridReact[propKey] = propType;

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
   },
   "peerDependencies": {
     "ag-grid": "10.0.x"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ag-grid": "10.0.x"
   },
   "dependencies": {
+    "create-react-class": "^15.5.3",
     "prop-types": "^15.5.10"
   }
 }

--- a/src/agGridReact.ts
+++ b/src/agGridReact.ts
@@ -7,8 +7,9 @@ var React = require('react');
 var ReactDOM = require('react-dom');
 var AgGrid = require('ag-grid');
 var PropTypes = require('prop-types');
+var createReactClass = require('create-react-class');
 
-export var AgGridReact = React.createClass({
+export var AgGridReact = createReactClass({
 
 
     render: function() {

--- a/src/agGridReact.ts
+++ b/src/agGridReact.ts
@@ -6,6 +6,7 @@ import {ReactFrameworkComponentWrapper} from "./reactFrameworkComponentWrapper";
 var React = require('react');
 var ReactDOM = require('react-dom');
 var AgGrid = require('ag-grid');
+var PropTypes = require('prop-types');
 
 export var AgGridReact = React.createClass({
 
@@ -82,16 +83,16 @@ export var AgGridReact = React.createClass({
 });
 
 AgGridReact.propTypes = {
-    gridOptions: React.PropTypes.object,
+    gridOptions: PropTypes.object,
 };
 
-addProperties(AgGrid.ComponentUtil.getEventCallbacks(), React.PropTypes.func);
-addProperties(AgGrid.ComponentUtil.BOOLEAN_PROPERTIES, React.PropTypes.bool);
-addProperties(AgGrid.ComponentUtil.STRING_PROPERTIES, React.PropTypes.string);
-addProperties(AgGrid.ComponentUtil.OBJECT_PROPERTIES, React.PropTypes.object);
-addProperties(AgGrid.ComponentUtil.ARRAY_PROPERTIES, React.PropTypes.array);
-addProperties(AgGrid.ComponentUtil.NUMBER_PROPERTIES, React.PropTypes.number);
-addProperties(AgGrid.ComponentUtil.FUNCTION_PROPERTIES, React.PropTypes.func);
+addProperties(AgGrid.ComponentUtil.getEventCallbacks(), PropTypes.func);
+addProperties(AgGrid.ComponentUtil.BOOLEAN_PROPERTIES, PropTypes.bool);
+addProperties(AgGrid.ComponentUtil.STRING_PROPERTIES, PropTypes.string);
+addProperties(AgGrid.ComponentUtil.OBJECT_PROPERTIES, PropTypes.object);
+addProperties(AgGrid.ComponentUtil.ARRAY_PROPERTIES, PropTypes.array);
+addProperties(AgGrid.ComponentUtil.NUMBER_PROPERTIES, PropTypes.number);
+addProperties(AgGrid.ComponentUtil.FUNCTION_PROPERTIES, PropTypes.func);
 
 function addProperties(listOfProps: string[], propType: any) {
     listOfProps.forEach( (propKey: string)=> {


### PR DESCRIPTION
I've made two changes to AgGrid to remove the deprecation warning messages that occur under React 15.5.

The changes are based on this doc from FB/React:

https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html

They're pretty straightforward:
* Replace `React.PropTypes` with a separate `PropTypes` package.
* Replace `React.createClass` with a separate `createReactClass` function.

There's no test suite, but in basic testing, everything seemed to work fine