### PR TITLE
VSCode gulp task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.1.0",
+  "command": "gulp",
+  "isShellCommand": true,
+  "args": [
+    "--no-color"
+  ],
+  "tasks": [
+    {
+      "taskName": "default",
+      "args": [],
+      "isBuildCommand": true,
+      "isBackground": false,
+      "problemMatcher": [
+        "$tsc"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds `.vscode/tasks.json` to easily run the default gulp task from VSCode (`Ctrl+Shift+B`/`Cmd+Shift+B`).